### PR TITLE
Fix binary encoding endianness issue for Docker compatibility

### DIFF
--- a/xmas-leds-esp32/lib/serverWeb/fileManager.cpp
+++ b/xmas-leds-esp32/lib/serverWeb/fileManager.cpp
@@ -114,7 +114,7 @@ bool convertCSVToBinary(const String &csvPath)
 
             //Serial.printf("ID: %d, R: %d, G: %d, B: %d\n", id, r, g, b);
             // Write binary data to file
-            binFile.write(id);
+            binFile.write((uint8_t *)&id, sizeof(id));
             binFile.write(r);
             binFile.write(g);
             binFile.write(b);

--- a/xmas-leds-esp32/lib/strip/strip.cpp
+++ b/xmas-leds-esp32/lib/strip/strip.cpp
@@ -139,21 +139,18 @@ void updateAnim()
     return;
   }
 
-  // Serial.printf("updateAnim '%s' : %d, %d\n", currentAnimFil.name(), duration, numLeds);
-
-  // Lire les données de chaque LED (1 octet pour l'ID, 3 octets pour les couleurs)
+  // Lire les données de chaque LED (2 octets pour l'ID, 3 octets pour les couleurs)
   for (uint16_t i = 0; i < numLeds; i++)
   {
     uint16_t id;
     uint8_t r, g, b;
 
-    // Lire l'ID de la LED (1 octet)
+    // Lire l'ID de la LED (2 octets)
     if (currentAnimFil.read((uint8_t *)&id, sizeof(id)) != sizeof(id))
     {
       Serial.println("Erreur lors de la lecture de l'ID de la LED");
       return;
     }
-    // Serial.printf("           '%s' : %d\n", currentAnimFil.name(), id);
 
     // Lire les couleurs R, G, B (1 octet chacune)
     if (currentAnimFil.read(&r, sizeof(r)) != sizeof(r) ||
@@ -164,8 +161,6 @@ void updateAnim()
       return;
     }
 
-    // Mettre à jour la couleur de la LED
-    // Serial.printf("updateAnim '%s' : %d, %d - %d, %d, %d, %d\n", currentAnimFil.name(), duration, numLeds, id, r, g, b);
     setPixel(id, RgbColor(r, g, b));
   }
 


### PR DESCRIPTION
- Replace writeUInt16LE() with explicit Little-Endian byte assignment in server
- Ensures consistent behavior across local and Docker environments
- Fixes LED ID corruption (e.g., 9216 instead of 0) when server runs in Docker
- Fix ESP32 file upload handler to write full 2 bytes for LED IDs
- Remove debug logging code from both server and ESP32 firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>