### PR TITLE
feat: add SessionStart hook to auto-load project rules

### DIFF
--- a/.claude/load-rules.sh
+++ b/.claude/load-rules.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Load project rules at session start
+
+if [ -f "$CLAUDE_PROJECT_DIR/.claude/project-rules.md" ]; then
+  echo "📋 === PROJECT RULES (AUTO-LOADED) ==="
+  echo ""
+  cat "$CLAUDE_PROJECT_DIR/.claude/project-rules.md"
+  echo ""
+  echo "=== END OF PROJECT RULES ==="
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": ["Skill"]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/load-rules.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a SessionStart hook configuration to automatically load project rules at the beginning of every Claude Code session.

## Changes

- ✅ Created `.claude/load-rules.sh` - Script that loads `project-rules.md` content
- ✅ Created `.claude/settings.json` - SessionStart hook configuration
- ✅ Made the script executable

## Why This Matters

The project has critical rules in `.claude/project-rules.md` (especially **NO COMMITS WITHOUT USER TESTING** for hardware). This ensures Claude automatically sees these rules at the start of every session, preventing mistakes.

## How It Works

1. When Claude Code starts a new session
2. The SessionStart hook executes `.claude/load-rules.sh`
3. The script outputs the content of `project-rules.md`
4. Claude receives this as context automatically

## Testing

✅ Script tested manually and works correctly
✅ Configuration follows Claude Code best practices
✅ No impact on existing code or hardware

## Files Changed

- `.claude/load-rules.sh` (new)
- `.claude/settings.json` (new)
