### PR TITLE
fix: create temp-uploads directory automatically on file upload

### DIFF
--- a/apps/api/src/app/admin/admin.module.ts
+++ b/apps/api/src/app/admin/admin.module.ts
@@ -3,6 +3,7 @@ import { AdminController } from './admin.controller';
 import { MulterModule } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { extname, join } from 'path';
+import { mkdirSync, existsSync } from 'fs';
 
 @Module({
   imports: [
@@ -10,6 +11,9 @@ import { extname, join } from 'path';
       storage: diskStorage({
         destination: (req, file, cb) => {
           const uploadPath = join(process.cwd(), 'data', '.temp-uploads');
+          if (!existsSync(uploadPath)) {
+            mkdirSync(uploadPath, { recursive: true });
+          }
           cb(null, uploadPath);
         },
         filename: (req, file, cb) => {


### PR DESCRIPTION
## Summary

- Corrige l'erreur 500 lors de l'upload d'un fichier CSV
- Le répertoire `.temp-uploads` est maintenant créé automatiquement s'il n'existe pas

## Cause du bug

Le répertoire `/usr/src/data/.temp-uploads/` n'existait pas dans le conteneur Docker, causant une erreur `ENOENT`.

## Solution

Ajout d'une vérification et création automatique du répertoire avant l'upload du fichier.

## Test plan

- [x] Testé en local - upload CSV fonctionne correctement

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)