### PR TITLE
fix: clamp Color values to valid RGB range (0-255)

### DIFF
--- a/libs/api-interfaces/src/lib/api-interfaces.ts
+++ b/libs/api-interfaces/src/lib/api-interfaces.ts
@@ -96,16 +96,22 @@ export class Color {
   b: number;
 
   constructor(r = Math.floor(Math.random() * 256), g = Math.floor(Math.random() * 256), b = Math.floor(Math.random() * 256)) {
-    this.r = r;
-    this.g = g;
-    this.b = b;
+    const clamp = (v: number) => Math.round(Math.max(0, Math.min(255, v)));
+    this.r = clamp(r);
+    this.g = clamp(g);
+    this.b = clamp(b);
   }
   static merge(c1: Color, c2: Color) {
     return Color.interpolate(c1, c2, 0.5);
   }
 
   static interpolate(c1: Color, c2: Color, t: number): Color {
-    return new Color(c1.r + (c2.r - c1.r) * t, c1.g + (c2.g - c1.g) * t, c1.b + (c2.b - c1.b) * t);
+    const clamp = (v: number) => Math.round(Math.max(0, Math.min(255, v)));
+    return new Color(
+      clamp(c1.r + (c2.r - c1.r) * t),
+      clamp(c1.g + (c2.g - c1.g) * t),
+      clamp(c1.b + (c2.b - c1.b) * t)
+    );
   }
 
   static toString(c: Color): string {


### PR DESCRIPTION
## Summary

- Corrige le bug des lumières rouge/bleu parasites après le playback d'animations
- Ajoute un clamping des valeurs RGB dans la classe `Color` pour garantir qu'elles sont toujours entre 0 et 255

## Cause du bug

La classe `Color` permettait des valeurs négatives ou supérieures à 255. Lors de l'interpolation de couleurs (dans `Color.interpolate()`), des calculs pouvaient produire des valeurs négatives (ex: `-97`). 

Ces valeurs étaient ensuite envoyées à l'ESP32 qui les interprétait comme des bytes non-signés :
- `-97` → `256 - 97 = 159` (rouge visible)
- `-45` → `256 - 45 = 211` (rouge intense)

## Solution

- Ajout d'un clamping dans le constructeur `Color` 
- Ajout d'un clamping et arrondi dans `Color.interpolate()`
- Les valeurs sont maintenant garanties d'être des entiers entre 0 et 255

## Test plan

- [x] Testé en local avec animation Haut-Bas
- [x] Vérifié sur le hardware - plus de lumières parasites rouge/bleu

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)