### PR TITLE
feat(esp32): custom partition for more storage + WiFi improvements

### DIFF
--- a/xmas-leds-esp32/lib/strip/strip.cpp
+++ b/xmas-leds-esp32/lib/strip/strip.cpp
@@ -243,14 +243,19 @@ void startNextAnim()
   // if program not loaded or ended, reload it
   if (!currentProgramFile || !currentProgramFile.available())
   {
+    static bool noProgramLogged = false;
     currentProgramFile.close();
-    Serial.println("Start program");
     currentProgramFile = LittleFS.open("/animations/program.csv", FILE_READ);
     if (!currentProgramFile || !currentProgramFile.available())
     {
-      Serial.printf("No program found !!\n");
+      if (!noProgramLogged) {
+        Serial.println("No program found");
+        noProgramLogged = true;
+      }
       return;
     }
+    noProgramLogged = false;  // Reset when program is found
+    Serial.println("Program loaded");
   }
 
   // read next line of the program

--- a/xmas-leds-esp32/partitions.csv
+++ b/xmas-leds-esp32/partitions.csv
@@ -1,0 +1,10 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Custom partition table for xmas-leds ESP32
+# Removes OTA app1 partition, keeps coredump for stability
+# Total flash: 4MB (0x400000)
+
+nvs,      data, nvs,     0x9000,  0x5000,
+otadata,  data, ota,     0xe000,  0x2000,
+app0,     app,  ota_0,   0x10000, 0x140000,
+spiffs,   data, spiffs,  0x150000,0x200000,
+coredump, data, coredump,0x350000,0x10000,

--- a/xmas-leds-esp32/platformio.ini
+++ b/xmas-leds-esp32/platformio.ini
@@ -20,6 +20,4 @@ monitor_speed = 115200
 ; monitor_speed = 9600
 
 board_build.filesystem = littlefs
-; board_build.ldscript = eagle.flash.4m3m.ld
-
-build_flags = -D FLASH_MAP_MAX_FS=1
+board_build.partitions = partitions.csv


### PR DESCRIPTION
## Summary

- Custom partition table with **2MB filesystem** (vs 1.4MB default) for more animation storage
- Skip config portal when valid WiFi credentials exist (direct connection avoids heap corruption bug)
- Auto-create `/animations` directory if missing on first upload
- Reduce verbose Serial logging to avoid upload slowdowns
- Log "No program found" only once instead of spamming

## Trade-offs

- ❌ Loses OTA (over-the-air) update capability (must flash via USB)
- ✅ Gains ~600KB extra storage for animations

Closes #38

## Test plan

- [x] Tested WiFi direct connection
- [x] Tested file upload to ESP32
- [x] Tested animation playback on hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)