### PR TITLE
feat: add dynamic color customization for image animations

### DIFF
--- a/apps/api/src/app/animation/animation.controller.ts
+++ b/apps/api/src/app/animation/animation.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Delete, FileTypeValidator, Get, HttpException, HttpStatus, Logger, MaxFileSizeValidator, Param, ParseFilePipe, Post, UploadedFile, UseInterceptors } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ApiReturn, Led, LedAnimation, Line } from '@xmas-leds/api-interfaces';
+import { ApiReturn, Color, Led, LedAnimation, Line } from '@xmas-leds/api-interfaces';
 import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
 import 'multer';
 import { diskStorage } from 'multer';
@@ -298,6 +298,26 @@ export class AnimationController {
     const animations = await this.animationService.getAllImageAnimations();
 
     return { images: animations };
+  }
+
+  // ====================================
+  // route to generate image animation with custom colors
+  // ====================================
+  @Post('/images/generate')
+  async generateImageWithColors(@Body('imageName') imageName: string, @Body('colors') colors: Color[]): Promise<ApiReturn> {
+    this.logger.log(`generateImageWithColors: imageName=${imageName}, colors=${JSON.stringify(colors)}`);
+    if (!imageName) {
+      throw new HttpException('Bad request: imageName required', HttpStatus.BAD_REQUEST);
+    }
+
+    const animation = this.animationService.generateImageWithColors(imageName, colors || []);
+
+    if (!animation) {
+      throw new HttpException(`Image not found: ${imageName}`, HttpStatus.NOT_FOUND);
+    }
+
+    this.logger.log(`generateImageWithColors: returning animation with ${animation.frames.length} frames`);
+    return { images: [animation] };
   }
 
   // ====================================

--- a/apps/api/src/app/animation/image-creator-abstract.ts
+++ b/apps/api/src/app/animation/image-creator-abstract.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { Color, ImageAnimation } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimation, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 
 export abstract class ImageCreatorAbstract {
   readonly logger = new Logger(ImageCreatorAbstract.name);
@@ -7,14 +7,16 @@ export abstract class ImageCreatorAbstract {
   abstract name: string;
   abstract width: number;
   abstract height: number;
+  abstract defaultColors: ImageAnimationColor[];
 
-  create(): ImageAnimation {
+  create(colors?: Color[]): ImageAnimation {
     this.logger.debug(`Creating image: ${this.name}`);
     return {
-        name: this.name,
-        frames: this.generateAnimationFrames(this.width, this.height)
-    }
-}
-    abstract generateAnimationFrames(width: number, height: number): Color[][][];
+      name: this.name,
+      frames: this.generateAnimationFrames(this.width, this.height, colors),
+      defaultColors: this.defaultColors,
+    };
+  }
 
+  abstract generateAnimationFrames(width: number, height: number, colors?: Color[]): Color[][][];
 }

--- a/apps/api/src/app/animation/image-creator-bonbons.ts
+++ b/apps/api/src/app/animation/image-creator-bonbons.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { Color } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 import { ImageCreatorAbstract } from './image-creator-abstract';
 
 export class ImageCreatorBonbons extends ImageCreatorAbstract {
@@ -8,21 +8,25 @@ export class ImageCreatorBonbons extends ImageCreatorAbstract {
   name: string = 'Bonbons';
   width = 20;
   height = 20;
+  defaultColors: ImageAnimationColor[] = [
+    new ImageAnimationColor('Couleur Fond', new Color(255, 255, 255)),
+    new ImageAnimationColor('Couleur Bord', new Color(0, 0, 0)),
+    new ImageAnimationColor('Couleur Centre', new Color(255, 0, 0)),
+  ];
 
   // Fonction pour créer une frame en déplaçant le dégradé vers le bas
-  createFrame(frameId: number, width: number, height: number) {
+  createFrame(frameId: number, width: number, height: number, colorBg: Color, colorBorder: Color, colorCenter: Color) {
     const frame = [];
-    // on initialise tous a blanc
+    // on initialise tous avec la couleur de fond
     for (let x = 0; x < height; x++) {
       const line = [];
-      const color = new Color(255, 255, 255);
       for (let y = 0; y < width; y++) {
-        line.push(color);
+        line.push(new Color(colorBg.r, colorBg.g, colorBg.b));
       }
       frame.push(line);
     }
 
-    // On fait les bandes noires
+    // On fait les bandes de bordure
     let departs = [];
     for (let i = -width / 5; i < width / 5; i++) {
       departs.push(i);
@@ -34,11 +38,11 @@ export class ImageCreatorBonbons extends ImageCreatorAbstract {
       for (let i = 0; i < width; i++) {
         x = (x + 1) % width;
         y = (height + y - 0.5) % height;
-        frame[Math.floor(y)][Math.floor(x)] = new Color(0, 0, 0);
+        frame[Math.floor(y)][Math.floor(x)] = new Color(colorBorder.r, colorBorder.g, colorBorder.b);
       }
     });
 
-    // On fait les bandes rouges
+    // On fait les bandes centrales
     departs = [];
     for (let i = -width / 10; i < width / 10; i++) {
       departs.push(i);
@@ -50,18 +54,22 @@ export class ImageCreatorBonbons extends ImageCreatorAbstract {
       for (let i = 0; i < width; i++) {
         x = (x + 1) % width;
         y = (height + y - 0.5) % height;
-        frame[Math.floor(y)][Math.floor(x)] = new Color(255, 0, 0);
+        frame[Math.floor(y)][Math.floor(x)] = new Color(colorCenter.r, colorCenter.g, colorCenter.b);
       }
     });
     return frame;
   }
 
   // Génère toutes les frames de l'animation
-  generateAnimationFrames(width: number, height: number) {
+  generateAnimationFrames(width: number, height: number, colors?: Color[]) {
+    const colorBg = colors?.[0] ?? this.defaultColors[0].color;
+    const colorBorder = colors?.[1] ?? this.defaultColors[1].color;
+    const colorCenter = colors?.[2] ?? this.defaultColors[2].color;
+
     const frames = [];
 
     for (let i = 0; i < height; i++) {
-      const frame = this.createFrame(i, width, height);
+      const frame = this.createFrame(i, width, height, colorBg, colorBorder, colorCenter);
       frames.push(frame);
     }
     return frames;

--- a/apps/api/src/app/animation/image-creator-diagonale.ts
+++ b/apps/api/src/app/animation/image-creator-diagonale.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { Color } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 import { ImageCreatorAbstract } from './image-creator-abstract';
 
 export class ImageCreatorDiagonale extends ImageCreatorAbstract {
@@ -8,16 +8,19 @@ export class ImageCreatorDiagonale extends ImageCreatorAbstract {
   name: string = 'Diagonale';
   width = 20;
   height = 20;
+  defaultColors: ImageAnimationColor[] = [
+    new ImageAnimationColor('Couleur Fond', new Color(255, 255, 255)),
+    new ImageAnimationColor('Couleur Bandes', new Color(0, 0, 255)),
+  ];
 
   // Fonction pour créer une frame en déplaçant le dégradé vers le bas
-  createFrame(frameId: number, width: number, height: number) {
+  createFrame(frameId: number, width: number, height: number, colorBg: Color, colorStripes: Color) {
     const frame = [];
-    // on initialise tous a blanc
+    // on initialise tous avec la couleur de fond
     for (let x = 0; x < height; x++) {
       const line = [];
-      const color = new Color(255, 255, 255);
       for (let y = 0; y < width; y++) {
-        line.push(color);
+        line.push(new Color(colorBg.r, colorBg.g, colorBg.b));
       }
       frame.push(line);
     }
@@ -33,7 +36,7 @@ export class ImageCreatorDiagonale extends ImageCreatorAbstract {
       for (let i = 0; i < width; i++) {
         x = (x + 1) % width;
         y = (y + 1) % height;
-        frame[Math.floor(y)][Math.floor(x)] = new Color(0, 0, 255);
+        frame[Math.floor(y)][Math.floor(x)] = new Color(colorStripes.r, colorStripes.g, colorStripes.b);
       }
     });
 
@@ -41,11 +44,14 @@ export class ImageCreatorDiagonale extends ImageCreatorAbstract {
   }
 
   // Génère toutes les frames de l'animation
-  generateAnimationFrames(width: number, height: number) {
+  generateAnimationFrames(width: number, height: number, colors?: Color[]) {
+    const colorBg = colors?.[0] ?? this.defaultColors[0].color;
+    const colorStripes = colors?.[1] ?? this.defaultColors[1].color;
+
     const frames = [];
 
     for (let i = 0; i < height; i++) {
-      const frame = this.createFrame(i, width, height);
+      const frame = this.createFrame(i, width, height, colorBg, colorStripes);
       frames.push(frame);
     }
     return frames;

--- a/apps/api/src/app/animation/image-creator-haut-bas-double.ts
+++ b/apps/api/src/app/animation/image-creator-haut-bas-double.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { Color } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 import { ImageCreatorAbstract } from './image-creator-abstract';
 
 export class ImageCreatorHautBasDouble extends ImageCreatorAbstract {
@@ -8,49 +8,52 @@ export class ImageCreatorHautBasDouble extends ImageCreatorAbstract {
   name: string = 'Haut-Bas-Double';
   width = 20;
   height = 20;
+  defaultColors: ImageAnimationColor[] = [
+    new ImageAnimationColor('Couleur Haut', new Color(0, 0, 255)),
+    new ImageAnimationColor('Couleur Bas', new Color(255, 0, 0)),
+  ];
 
-    // Fonction pour créer une frame en déplaçant le dégradé vers le bas
-    createFrame(frameId: number, width: number, height: number) {
-      const frame = [];
-      // Utilise l'offset pour décaler le gradient verticalement
-      for (let x = 0; x < height; x++) {
-        let color1 = new Color(0, 0, 0);
-        let color2 = new Color(0, 0, 0);
-        if (x < frameId) {
-          const r = 0 * (1-(frameId-x)/height);
-          const g = 0 * (1-(frameId-x)/height);
-          const b = 255 * (1-(frameId-x)/height);
-          color1 = new Color(r, g, b);
-        }
-        if ((height-x) < frameId) {
-          const r = 255 * (1-(frameId-(height-x))/height);
-          const g = 0 * (1-(frameId-x)/height);
-          const b = 0 * (1-(frameId-x)/height);
-          color2 = new Color(r, g, b);
-        }
-        const line = [];
-        for (let y = 0; y < width; y++) {
-          line.push(Color.merge(color1, color2));
-        }
-        frame.push(line);
+  // Fonction pour créer une frame en déplaçant le dégradé vers le bas
+  createFrame(frameId: number, width: number, height: number, colorTop: Color, colorBottom: Color) {
+    const frame = [];
+    // Utilise l'offset pour décaler le gradient verticalement
+    for (let x = 0; x < height; x++) {
+      let color1 = new Color(0, 0, 0);
+      let color2 = new Color(0, 0, 0);
+      if (x < frameId) {
+        const ratio = 1 - (frameId - x) / height;
+        color1 = new Color(colorTop.r * ratio, colorTop.g * ratio, colorTop.b * ratio);
       }
-  
-      return frame;
+      if (height - x < frameId) {
+        const ratio = 1 - (frameId - (height - x)) / height;
+        color2 = new Color(colorBottom.r * ratio, colorBottom.g * ratio, colorBottom.b * ratio);
+      }
+      const line = [];
+      for (let y = 0; y < width; y++) {
+        line.push(Color.merge(color1, color2));
+      }
+      frame.push(line);
     }
-  
-    // Génère toutes les frames de l'animation
-    generateAnimationFrames(width: number, height: number) {
-      const frames = [];
-  
-      for (let i = 0; i < 2*height; i++) {
-        const frame = this.createFrame(i, width, height);
-        frames.push(frame);
-      }
-      for (let i = 2*height-1; i >= 0; i--) {
-        const frame = this.createFrame(i, width, height);
-        frames.push(frame);
-      }
-      return frames;
-    }
+
+    return frame;
   }
+
+  // Génère toutes les frames de l'animation
+  generateAnimationFrames(width: number, height: number, colors?: Color[]) {
+    const colorTop = colors?.[0] ?? this.defaultColors[0].color;
+    const colorBottom = colors?.[1] ?? this.defaultColors[1].color;
+
+    const frames = [];
+
+    for (let i = 0; i < 2 * height; i++) {
+      const frame = this.createFrame(i, width, height, colorTop, colorBottom);
+      frames.push(frame);
+    }
+    for (let i = 2 * height - 1; i >= 0; i--) {
+      const frame = this.createFrame(i, width, height, colorTop, colorBottom);
+      frames.push(frame);
+    }
+    return frames;
+  }
+}
   

--- a/apps/api/src/app/animation/image-creator-haut-bas.ts
+++ b/apps/api/src/app/animation/image-creator-haut-bas.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { Color } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 import { ImageCreatorAbstract } from './image-creator-abstract';
 
 export class ImageCreatorHautBas extends ImageCreatorAbstract {
@@ -8,45 +8,48 @@ export class ImageCreatorHautBas extends ImageCreatorAbstract {
   name: string = 'Haut-Bas';
   width = 20;
   height = 20;
+  defaultColors: ImageAnimationColor[] = [
+    new ImageAnimationColor('Couleur Haut', new Color(0, 0, 255)),
+    new ImageAnimationColor('Couleur Bas', new Color(255, 0, 0)),
+  ];
 
-    // Fonction pour créer une frame en déplaçant le dégradé vers le bas
-    createFrame(frameId: number, width: number, height: number) {
-      const frame = [];
-      // Utilise l'offset pour décaler le gradient verticalement
-      for (let x = 0; x < height; x++) {
-        let color1 = new Color(0, 0, 0);
-        let color2 = new Color(0, 0, 0);
-        if (x < frameId) {
-          const r = 0 * (1-(frameId-x)/height);
-          const g = 0 * (1-(frameId-x)/height);
-          const b = 255 * (1-(frameId-x)/height);
-          color1 = new Color(r, g, b);
-        }
-        if ((height-x) < frameId) {
-          const r = 255 * (1-(frameId-(height-x))/height);
-          const g = 0 * (1-(frameId-x)/height);
-          const b = 0 * (1-(frameId-x)/height);
-          color2 = new Color(r, g, b);
-        }
-        const line = [];
-        for (let y = 0; y < width; y++) {
-          line.push(Color.merge(color1, color2));
-        }
-        frame.push(line);
+  // Fonction pour créer une frame en déplaçant le dégradé vers le bas
+  createFrame(frameId: number, width: number, height: number, colorTop: Color, colorBottom: Color) {
+    const frame = [];
+    // Utilise l'offset pour décaler le gradient verticalement
+    for (let x = 0; x < height; x++) {
+      let color1 = new Color(0, 0, 0);
+      let color2 = new Color(0, 0, 0);
+      if (x < frameId) {
+        const ratio = 1 - (frameId - x) / height;
+        color1 = new Color(colorTop.r * ratio, colorTop.g * ratio, colorTop.b * ratio);
       }
-  
-      return frame;
-    }
-  
-    // Génère toutes les frames de l'animation
-    generateAnimationFrames(width: number, height: number) {
-      const frames = [];
-  
-      for (let i = 0; i < 2*height; i++) {
-        const frame = this.createFrame(i, width, height);
-        frames.push(frame);
+      if (height - x < frameId) {
+        const ratio = 1 - (frameId - (height - x)) / height;
+        color2 = new Color(colorBottom.r * ratio, colorBottom.g * ratio, colorBottom.b * ratio);
       }
-      return frames;
+      const line = [];
+      for (let y = 0; y < width; y++) {
+        line.push(Color.merge(color1, color2));
+      }
+      frame.push(line);
     }
+
+    return frame;
   }
+
+  // Génère toutes les frames de l'animation
+  generateAnimationFrames(width: number, height: number, colors?: Color[]) {
+    const colorTop = colors?.[0] ?? this.defaultColors[0].color;
+    const colorBottom = colors?.[1] ?? this.defaultColors[1].color;
+
+    const frames = [];
+
+    for (let i = 0; i < 2 * height; i++) {
+      const frame = this.createFrame(i, width, height, colorTop, colorBottom);
+      frames.push(frame);
+    }
+    return frames;
+  }
+}
   

--- a/apps/api/src/app/animation/image-creator-rainbow.ts
+++ b/apps/api/src/app/animation/image-creator-rainbow.ts
@@ -1,21 +1,15 @@
-import { ImageAnimation } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 import { ImageCreatorAbstract } from './image-creator-abstract';
 import { Logger } from '@nestjs/common';
 
 export class ImageCreatorRainbow extends ImageCreatorAbstract {
-    readonly logger = new Logger(ImageCreatorRainbow.name);
-    
-    name: string = "Arc-en-Ciel";
-    width = 20;
-    height = 20;
+  readonly logger = new Logger(ImageCreatorRainbow.name);
 
-    create(): ImageAnimation {
-        this.logger.debug(`Creating image: ${this.name}`);
-        return {
-            name: this.name,
-            frames: this.generateAnimationFrames(20, 20)
-        }
-    }
+  name: string = 'Arc-en-Ciel';
+  width = 20;
+  height = 20;
+  // L'arc-en-ciel n'a pas de couleurs personnalisables (généré mathématiquement)
+  defaultColors: ImageAnimationColor[] = [];
 
   // Fonction pour générer une couleur RGB en fonction de la position dans l'arc-en-ciel
   rainbowColor(position: number, maxPosition: number) {
@@ -24,7 +18,7 @@ export class ImageCreatorRainbow extends ImageCreatorAbstract {
     const green = Math.round(Math.sin(frequency * position + (2 * Math.PI) / 3) * 127 + 128);
     const blue = Math.round(Math.sin(frequency * position + (4 * Math.PI) / 3) * 127 + 128);
     return { r: red, g: green, b: blue };
-    }
+  }
 
   // Génère le dégradé de l'arc-en-ciel pour une frame
   generateRainbowGradient(height: number) {
@@ -37,7 +31,7 @@ export class ImageCreatorRainbow extends ImageCreatorAbstract {
   }
 
   // Fonction pour créer une frame en déplaçant le dégradé vers le bas
-  createFrame(gradient, offset, width: number, height: number) {
+  createFrame(gradient: Color[], offset: number, width: number, height: number) {
     const frame = [];
     for (let y = 0; y < height; y++) {
       const row = [];
@@ -52,7 +46,8 @@ export class ImageCreatorRainbow extends ImageCreatorAbstract {
   }
 
   // Génère toutes les frames de l'animation
-  generateAnimationFrames(width: number, height: number) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  generateAnimationFrames(width: number, height: number, colors?: Color[]) {
     const frames = [];
     const gradient = this.generateRainbowGradient(height);
 
@@ -62,5 +57,4 @@ export class ImageCreatorRainbow extends ImageCreatorAbstract {
     }
     return frames;
   }
-
 } 

--- a/apps/api/src/app/animation/image-creator-snow.ts
+++ b/apps/api/src/app/animation/image-creator-snow.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@nestjs/common';
 import { ImageCreatorAbstract } from './image-creator-abstract';
-import { Color } from '@xmas-leds/api-interfaces';
+import { Color, ImageAnimationColor } from '@xmas-leds/api-interfaces';
 
 export class ImageCreatorSnow extends ImageCreatorAbstract {
   readonly logger = new Logger(ImageCreatorSnow.name);
@@ -8,16 +8,19 @@ export class ImageCreatorSnow extends ImageCreatorAbstract {
   name: string = 'Neige';
   width = 20;
   height = 20;
+  defaultColors: ImageAnimationColor[] = [
+    new ImageAnimationColor('Couleur Neige', new Color(255, 255, 255)),
+  ];
 
   // Fonction pour créer une frame en déplaçant le dégradé vers le bas
-  createFrame(frameId: number, width: number, height: number) {
+  createFrame(frameId: number, width: number, height: number, colorSnow: Color) {
     const frame = [];
     // Utilise l'offset pour décaler le gradient verticalement
     for (let x = 0; x < height; x++) {
       let color = new Color(0, 0, 0);
       if (x < frameId) {
-        const c = 255 * (1-(frameId-x)/height);
-        color = new Color(c, c, c);
+        const ratio = 1 - (frameId - x) / height;
+        color = new Color(colorSnow.r * ratio, colorSnow.g * ratio, colorSnow.b * ratio);
       }
       const line = [];
       for (let y = 0; y < width; y++) {
@@ -30,11 +33,13 @@ export class ImageCreatorSnow extends ImageCreatorAbstract {
   }
 
   // Génère toutes les frames de l'animation
-  generateAnimationFrames(width: number, height: number) {
+  generateAnimationFrames(width: number, height: number, colors?: Color[]) {
+    const colorSnow = colors?.[0] ?? this.defaultColors[0].color;
+
     const frames = [];
 
-    for (let i = 0; i < 2*height; i++) {
-      const frame = this.createFrame(i, width, height);
+    for (let i = 0; i < 2 * height; i++) {
+      const frame = this.createFrame(i, width, height, colorSnow);
       frames.push(frame);
     }
     return frames;

--- a/apps/frontend/src/app/animation/animation-display/animation-display.component.html
+++ b/apps/frontend/src/app/animation/animation-display/animation-display.component.html
@@ -32,6 +32,19 @@
         <div *ngIf="option.type !== 2" class="pr-4">{{ option.name }}</div>
         <div *ngIf="option.type === 0">{{ option.valueN }} {{ option.unit }}</div>
         <div *ngIf="option.type === 1" class="border-neutral-dark border" [style.background-color]="option.valueS"></div>
+        <div *ngIf="option.type === 3">
+          <xmas-leds-pixel-canvas
+            *ngIf="getAnimImage(anim)"
+            [size]="40"
+            [sizeHover]="40"
+            [image]="getAnimImage(anim)!"
+            title="{{option.valueI?.name}}"></xmas-leds-pixel-canvas>
+          <span *ngIf="!getAnimImage(anim)">{{ option.valueI?.name || 'Non définie' }}</span>
+        </div>
+        }
+        @for (colorOpt of getImageColors(anim); track colorOpt.name) {
+        <div class="pr-4">{{ colorOpt.name }}</div>
+        <div class="border-neutral-dark border" [style.background-color]="colorOpt.valueS"></div>
         }
       </div>
     </mat-expansion-panel>

--- a/apps/frontend/src/app/animation/animation-editor/animation-editor.component.html
+++ b/apps/frontend/src/app/animation/animation-editor/animation-editor.component.html
@@ -41,22 +41,31 @@
   <div *ngIf="option.type === 3 && option.valueI" class="pb-6 flex flex-row items-center">
     @for (image of imageAnimations; track image.name) {
       <div class="flex flex-col p-1" >
-        <xmas-leds-pixel-canvas 
-          *ngIf="option.valueI.name === image.name" 
-          [size]="100" 
-          [sizeHover]="100" 
-          [image]="image" 
+        <xmas-leds-pixel-canvas
+          *ngIf="option.valueI.name === image.name"
+          [size]="100"
+          [sizeHover]="100"
+          [image]="image"
           title="{{image.name}}"></xmas-leds-pixel-canvas>
-        <xmas-leds-pixel-canvas 
-          *ngIf="option.valueI.name !== image.name" 
+        <xmas-leds-pixel-canvas
+          *ngIf="option.valueI.name !== image.name"
           (click)="onImageClick(image)"
-          [size]="30"  
-          [sizeHover]="80" 
-          [image]="image" 
+          [size]="30"
+          [sizeHover]="80"
+          [image]="image"
           title="{{image.name}}"></xmas-leds-pixel-canvas>
       </div>
     }
   </div>
+  }
+  <!-- Options de couleur dynamiques pour l'animation Image -->
+  @for (colorOption of getImageColorOptions(); track colorOption.name) {
+  <mat-form-field class="">
+    <mat-label>{{ colorOption.name }}</mat-label>
+    <input matInput [ngxMatColorPicker]="imagePicker" [formControl]="colorCtrs[colorOption.name]">
+    <ngx-mat-color-toggle matSuffix [for]="imagePicker"></ngx-mat-color-toggle>
+    <ngx-mat-color-picker #imagePicker></ngx-mat-color-picker>
+  </mat-form-field>
   }
 
   <!-- <hr />

--- a/apps/frontend/src/app/animation/animation.service.ts
+++ b/apps/frontend/src/app/animation/animation.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { ApiReturn, ImageAnimation, Led, LedAnimation, LedAnimOptionImage, LedProgram, Line } from '@xmas-leds/api-interfaces';
+import { ApiReturn, Color, ImageAnimation, Led, LedAnimation, LedProgram, Line } from '@xmas-leds/api-interfaces';
 import { lastValueFrom, map, Subject } from 'rxjs';
 import { ConfigService } from '../config.service';
 import { LedsService } from '../leds/leds.service';
@@ -65,6 +65,21 @@ export class AnimationService {
       )
     );
     return animations;
+  }
+
+  async generateImageWithColors(imageName: string, colors: Color[]): Promise<ImageAnimation | undefined> {
+    console.log('generateImageWithColors', imageName, colors);
+    const animation = await lastValueFrom(
+      this.httpClient
+        .post<ApiReturn>(`/api/anim/images/generate`, { imageName, colors })
+        .pipe(
+          map((data) => {
+            console.log('generateImageWithColors response', data);
+            return data?.images?.[0];
+          })
+        )
+    );
+    return animation;
   }
 
   async visuByLine(lines: Line[], divisor = 1): Promise<void> {

--- a/apps/frontend/src/app/animation/led-animation-abstract.ts
+++ b/apps/frontend/src/app/animation/led-animation-abstract.ts
@@ -33,11 +33,11 @@ export abstract class LedAnimationAbstract implements LedAnimation {
   /**
    * Calculate the animations
    */
-  abstract calculateInternal: ((points: Point[]) => void) | undefined;
-  calculate(points: Point[]) {
+  abstract calculateInternal: ((points: Point[]) => void | Promise<void>) | undefined;
+  async calculate(points: Point[]) {
     this.initOptions();
     if (this.calculateInternal) {
-      this.calculateInternal(points);
+      await this.calculateInternal(points);
     }
   }
 

--- a/libs/api-interfaces/src/lib/api-interfaces.ts
+++ b/libs/api-interfaces/src/lib/api-interfaces.ts
@@ -168,9 +168,20 @@ export interface LedAnimation {
   // execOnTree?(): void;
 }
 
+export class ImageAnimationColor {
+  name = '';
+  color: Color = new Color(0, 0, 0);
+
+  constructor(name: string, color: Color) {
+    this.name = name;
+    this.color = color;
+  }
+}
+
 export class ImageAnimation {
   name = '';
   frames: Color[][][] = [];
+  defaultColors: ImageAnimationColor[] = [];
 }
 
 export abstract class LedAnimOption {

--- a/package-lock.json
+++ b/package-lock.json
@@ -324,6 +324,7 @@
       "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-17.0.6.tgz",
       "integrity": "sha512-+h9VnFHof7rKzBJ5FWrbPXWzbag31QKbUGJ/mV5BYgj39vjzPNUXBW8AaScZAlATi8+tElYXjRMvM49GnuyRLg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
@@ -351,6 +352,7 @@
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-17.0.6.tgz",
       "integrity": "sha512-2g769MpazA1aOzJOm2MNGosra3kxw8CbdIQQOKkvycIzroRNgN06yHcRTDC03GADgP/CkDJ6kxwJQNG+wNFL2A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "17.0.6",
         "jsonc-parser": "3.2.0",
@@ -450,6 +452,7 @@
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-17.0.6.tgz",
       "integrity": "sha512-fic61LjLHry79c5H9UGM8Ff311MJnf9an7EukLj2aLJ3J0uadL/H9de7dDp8PaIT10DX9g+aRTIKOmF3PmmXIQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -464,6 +467,7 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-17.0.3.tgz",
       "integrity": "sha512-Qd5uvC09B3+uk2uX1JxmiWrD7wueMHSxNBoCbDEmnrsdDVUta0wN/jj/CtATljxUM8ZqvEvkqgxJCig1od9oyQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -526,6 +530,7 @@
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-17.0.6.tgz",
       "integrity": "sha512-FZtf8ol8W2V21ZDgFtcxmJ6JJKUO97QZ+wr/bosyYEryWMmn6VGrbOARhfW7BlrEgn14NdFkLb72KKtqoqRjrg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -541,6 +546,7 @@
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-17.0.6.tgz",
       "integrity": "sha512-PaCNnlPcL0rvByKCBUUyLWkKJYXOrcfKlYYvcacjOzEUgZeEpekG81hMRb9u/Pz+A+M4HJSTmdgzwGP35zo8qw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -561,6 +567,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-17.0.6.tgz",
       "integrity": "sha512-C1Gfh9kbjYZezEMOwxnvUTHuPXa+6pk7mAfSj8e5oAO6E+wfo2dTxv1J5zxa3KYzxPYMNfF8OFvLuMKsw7lXjA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.23.2",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -588,6 +595,7 @@
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-17.0.6.tgz",
       "integrity": "sha512-QzfKRTDNgGOY9D5VxenUUz20cvPVC+uVw9xiqkDuHgGfLYVFlCAK9ymFYkdUCLTcVzJPxckP+spMpPX8nc4Aqw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -603,6 +611,7 @@
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-17.0.6.tgz",
       "integrity": "sha512-n/trsMtQHUBGiWz5lFaggMcMOuw0gH+96TCtHxQiUYJOdrbOemkFdGrNh3B4fGHmogWuOYJVF5FAm97WRES2XA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -629,6 +638,7 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@angular/material/-/material-17.0.3.tgz",
       "integrity": "sha512-a7l5hMMCMobULAjwPK8HVQmOsbd3pOwju1QdBVhec0XwNGj2pK4ooKWdUmQcwsUA9DaZaOwAgEISHEADXJfKpQ==",
+      "peer": true,
       "dependencies": {
         "@material/animation": "15.0.0-canary.a246a4439.0",
         "@material/auto-init": "15.0.0-canary.a246a4439.0",
@@ -693,6 +703,7 @@
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-17.0.6.tgz",
       "integrity": "sha512-nBhWH1MKT2WswgRNIoMnmNAt0n5/fG59BanJtodW71//Aj5aIE+BuVoFgK3wmO8IMoeP4i4GXRInBXs6lUMOJw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -777,6 +788,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -2731,7 +2743,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2748,7 +2759,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2765,7 +2775,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2782,7 +2791,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2799,7 +2807,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2816,7 +2823,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2833,7 +2839,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2850,7 +2855,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2867,7 +2871,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2884,7 +2887,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2901,7 +2903,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2918,7 +2919,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2935,7 +2935,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2952,7 +2951,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2969,7 +2967,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2986,7 +2983,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3003,7 +2999,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3020,7 +3015,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3037,7 +3031,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3054,7 +3047,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3071,7 +3063,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3088,7 +3079,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4879,6 +4869,7 @@
       "version": "10.2.10",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.2.10.tgz",
       "integrity": "sha512-fwAk931rjW8CNH2Mgwawq/7HWHH1dxkOLdcgs7U52ddLk8CtHXjejm1cbNahewlSbNhvlOl7y1STLHutE6sUqw==",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "tslib": "2.6.2",
@@ -4931,6 +4922,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.10.tgz",
       "integrity": "sha512-+ckOI6BPi2ZMHikT9MCG4ctHDc4OnjhoIytrn7f2AYMMXI4bnutJhqyQKc30VDka5x3Wq6QAD57pgSP7y+JjJg==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -4967,6 +4959,7 @@
       "version": "10.2.10",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.2.10.tgz",
       "integrity": "sha512-U4KDgtMjH8TqEvt0RzC/POP8ABvL9bYoCScvlGtFSKgVGaMLBKkZ4+jHtbQx6qItYSlBBRUuz/dveMZCObfrkQ==",
+      "peer": true,
       "dependencies": {
         "body-parser": "1.20.2",
         "cors": "2.8.5",
@@ -5147,6 +5140,7 @@
       "version": "10.4.7",
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-10.4.7.tgz",
       "integrity": "sha512-ajuoptYLYm+l3+KtaA9Ed+cO9yB34PtBE8UObavRT8Euh/f7QfeJiKcrU3+BQSAiTWM3nF2qfuV4CfEkP9uKuw==",
+      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -7190,6 +7184,7 @@
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-17.0.6.tgz",
       "integrity": "sha512-AyC7Bk3Omy6PfADThhq5ci+zzdTTi2N1oZI35gw4tMK5ZxVwIACx2Zyhaz399m5c2RCDi9Hz4A2BOFq9f0j/dg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "17.0.6",
         "@angular-devkit/schematics": "17.0.6",
@@ -7300,6 +7295,7 @@
       "resolved": "https://registry.npmjs.org/@swc-node/register/-/register-1.6.8.tgz",
       "integrity": "sha512-74ijy7J9CWr1Z88yO+ykXphV29giCrSpANQPQRooE0bObpkTO1g4RzQovIfbIaniBiGDDVsYwDoQ3FIrCE8HcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@swc-node/core": "^1.10.6",
         "@swc-node/sourcemap-support": "^0.3.0",
@@ -7333,6 +7329,7 @@
       "integrity": "sha512-zKhqDyFcTsyLIYK1iEmavljZnf4CCor5pF52UzLAz4B6Nu/4GLU+2LQVAf+oRHjusG39PTPjd2AlRT3f3QWfsQ==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.1",
         "@swc/types": "^0.1.5"
@@ -7536,6 +7533,7 @@
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz",
       "integrity": "sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -7905,7 +7903,8 @@
     "node_modules/@types/node": {
       "version": "18.7.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.23.tgz",
-      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg=="
+      "integrity": "sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==",
+      "peer": true
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.10",
@@ -8182,6 +8181,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.2.tgz",
       "integrity": "sha512-MUkcC+7Wt/QOGeVlM8aGGJZy1XV5YKjTpq9jK6r6/iLsGXhBVaGP5N0UYvFsu9BFlSpwY9kMretzdBH01rkRXg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.13.2",
         "@typescript-eslint/types": "6.13.2",
@@ -8714,6 +8714,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8831,6 +8832,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9368,6 +9370,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
       "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -10269,6 +10272,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001565",
         "electron-to-chromium": "^1.4.601",
@@ -10612,6 +10616,7 @@
           "url": "https://paulmillr.com/funding/"
         }
       ],
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -12228,6 +12233,7 @@
       "integrity": "sha512-k1Wl5PQcA/4UoTffYKKaxA0FJKwg8yenYNYRzLt11CUR0Kln+h7Udne6mdU1cUIdXBDTVZWtmiUjzqGs7/pEpw==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
@@ -13399,6 +13405,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.46.0.tgz",
       "integrity": "sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13453,6 +13460,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -14569,6 +14577,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -16623,6 +16632,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
       "integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.5.0",
         "@jest/types": "^29.5.0",
@@ -16748,24 +16758,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -16807,7 +16799,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -17260,6 +17251,7 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.5.0.tgz",
       "integrity": "sha512-/KG8yEK4aN8ak56yFVdqFDzKNHgF4BAymCx2LbPNPsUshUlfAl0eX402Xm1pt+eoG9SLZEUVifqXtX8SK74KCw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.5.0",
         "@jest/fake-timers": "^29.5.0",
@@ -18679,6 +18671,7 @@
       "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
       "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -20771,6 +20764,7 @@
       "integrity": "sha512-6LYoTt01nS1d/dvvYtRs+pEAMQmUVsd2fr/a8+X1cDjWrb8wsf1O3DwlBTqKOXOazpS3eOr0Ukc9N1svbu7uXA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nrwl/tao": "17.1.3",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -21692,6 +21686,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -22986,7 +22981,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
-      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
+      "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
+      "peer": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -23369,6 +23365,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -23407,6 +23404,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
       "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -24703,6 +24701,7 @@
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.59.0.tgz",
       "integrity": "sha512-lQ9w/XIOH5ZHVNuNbWW8D822r+/wBSO/d6XvtyHLF7LW4KaCIDeVbvn5DF8fGCJAUCwVhVi/h6J0NUcnylUEjg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.0.1",
         "debug": "^4.3.2",
@@ -24882,6 +24881,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.6.tgz",
       "integrity": "sha512-AKjF7qbbLvLaPieoKeTjG1+FyNZT6KaJMJPFeQyLfIp7l82ggH1fbHJSsYIvnbTFQOlkh+gBYpyby5GT1LIdLw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -25061,6 +25061,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
       "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -25113,6 +25114,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -25837,6 +25839,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -26189,6 +26192,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
       "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -26699,6 +26703,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -26774,6 +26779,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -26927,6 +26933,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27402,6 +27409,7 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.2.tgz",
       "integrity": "sha512-X4U7J1isDhoOmHmFWiLhloWc2lzMkdnumtfQ1LXzf/IOZp5NQYuMUTaviVzG/q1ugMBIXzin2AqeVJUoSEkNyQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       }


### PR DESCRIPTION
## Summary

Closes #41

- Add `defaultColors` support to all ImageCreators (Haut-Bas, Bonbons, Diagonale, Rainbow, Snow, Haut-Bas-Double)
- Add API endpoint `/api/anim/images/generate` to generate images with custom colors
- Add dynamic color pickers in animation editor that appear based on the selected image type
- Persist custom colors in animation CSV via JSON serialization in the `valueS` field
- Display image preview (pixel canvas) and custom colors in program summary view
- Fix negative RGB values bug by clamping interpolated values to [0, 255] range

## Test plan

- [x] Create a new Image animation and verify color pickers appear based on selected image
- [x] Modify colors and generate animation - verify colors are applied
- [x] Save animation, select another, then re-select - verify colors are restored
- [x] Verify program summary shows image preview and custom colors
- [x] Test all image types (Haut-Bas, Bonbons, Diagonale, etc.)
- [x] Verify on actual LED hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)